### PR TITLE
fix: the text color is now readable with a darker color on the succes…

### DIFF
--- a/src/components/Popups/TransactionPopup.tsx
+++ b/src/components/Popups/TransactionPopup.tsx
@@ -35,7 +35,7 @@ export default function TransactionPopup({
         )}
       </div>
       <AutoColumn gap="8px">
-        <Text>{summary ?? `Hash: ${hash.slice(0, 8)}...${hash.slice(58, 65)}`}</Text>
+        <Text style={{color: '#545c67'}}>{summary ?? `Hash: ${hash.slice(0, 8)}...${hash.slice(58, 65)}`}</Text>
         {chainId && <ExternalLink href={getBscScanLink(chainId, hash, 'transaction')}>View on bscscan</ExternalLink>}
       </AutoColumn>
     </RowNoFlex>


### PR DESCRIPTION
…s message from a swap/exchange

- fixed: On a swap success action, the toast notification text wasn’t readable (color wise). Fixed the color and made it darker inside. Text color change occurred inside `TransactionPopup.tsx `component inside the `src/components/popups` folder